### PR TITLE
`use rosrust::Time as TimeMsg` if rosrust_msg is active

### DIFF
--- a/src/ros_types.rs
+++ b/src/ros_types.rs
@@ -1,14 +1,19 @@
+#[cfg(not(feature = "rosrust_msg"))]
 #[derive(Clone, Debug)]
 pub struct TimeMsg {
     pub sec: u32,
     pub nsec: u32,
 }
 
+#[cfg(not(feature = "rosrust_msg"))]
 impl Default for TimeMsg {
     fn default() -> Self {
         Self { sec: 0, nsec: 0 }
     }
 }
+
+#[cfg(feature = "rosrust_msg")]
+pub use rosrust::Time as TimeMsg;
 
 #[derive(Clone, Debug)]
 pub struct HeaderMsg {


### PR DESCRIPTION
this helps when implementing traits for this crate's types.
alternatives: implement `From<Time> for TimeMsg` (and vice versa)