### PR TITLE
fix: pack rgb seems to be wrong #9

### DIFF
--- a/src/pcl_utils.rs
+++ b/src/pcl_utils.rs
@@ -3,12 +3,12 @@ use crate::{ConversionError, MetaNames, PointConvertible, PointMeta};
 #[inline]
 fn pack_rgb(r: u8, g: u8, b: u8) -> f32 {
     let packed = ((r as u32) << 16) + ((g as u32) << 8) + (b as u32);
-    unsafe { std::mem::transmute(packed) }
+    f32::from_bits(packed)
 }
 
 #[inline]
 fn unpack_rgb(rgb: f32) -> [u8; 3] {
-    let packed: u32 = unsafe { std::mem::transmute(rgb) };
+    let packed: u32 = rgb.to_bits();
     let r: u8 = (packed >> 16) as u8;
     let g: u8 = (packed >> 8) as u8;
     let b: u8 = packed as u8;

--- a/src/pcl_utils.rs
+++ b/src/pcl_utils.rs
@@ -2,14 +2,16 @@ use crate::{ConversionError, MetaNames, PointConvertible, PointMeta};
 
 #[inline]
 fn pack_rgb(r: u8, g: u8, b: u8) -> f32 {
-    ((r as u32) << 16) as f32 + ((g as u32) << 8) as f32 + (b as u32) as f32
+    let packed = ((r as u32) << 16) + ((g as u32) << 8) + (b as u32);
+    unsafe { std::mem::transmute(packed) }
 }
 
 #[inline]
 fn unpack_rgb(rgb: f32) -> [u8; 3] {
-    let r: u8 = ((rgb as u32) >> 16) as u8;
-    let g: u8 = ((rgb as u32) >> 8) as u8;
-    let b: u8 = (rgb as u32) as u8;
+    let packed: u32 = unsafe { std::mem::transmute(rgb) };
+    let r: u8 = (packed >> 16) as u8;
+    let g: u8 = (packed >> 8) as u8;
+    let b: u8 = packed as u8;
     [r, g, b]
 }
 


### PR DESCRIPTION
Casting f32 to u32 is not bitwise in Rust.

This PR uses safe bitwise reinterpretation of the type, which is equivalent to `std::mem::transmute`.